### PR TITLE
Add CPL Marker Labels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
         path: build/register.pdf
   
     - name: Add artifact links to the pull request
+      if: github.event_name == 'pull_request'
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         message: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,30 @@ jobs:
       with:
         path: build/
 
+  artifact:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: markwilson/html2pdf@v1.0
+        with:
+          htmlPath: build/index.html
+          pdfName: build/register.pdf
+
+      - name: Upload the PDF as an artifact
+        id: pdf-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: register
+          path: build/register.pdf
+      
+      - name: Add artifact links to the pull request
+        if: steps.finder
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            Rendered register: <${{ steps.pdf-artifact.outputs.artifact-url}}>
+
   deploy:
     if: github.ref_name == github.event.repository.default_branch
     environment:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,10 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request'
     steps:
-      - uses: markwilson/html2pdf@v1.0
+      - uses: ferdinandkeller/html-to-pdf-action@v2
         with:
-          htmlPath: build/index.html
-          pdfName: build/register
+          - source-path: build/index.html
+          - destination-path: build/register.pdf
 
       - name: Upload the PDF as an artifact
         id: pdf-artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,8 @@ jobs:
     steps:
       - uses: ferdinandkeller/html-to-pdf-action@v2
         with:
-          - source-path: build/index.html
-          - destination-path: build/register.pdf
+          source-path: build/index.html
+          destination-path: build/register.pdf
 
       - name: Upload the PDF as an artifact
         id: pdf-artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
         path: build/register.pdf
   
     - name: Add artifact links to the pull request
+      if: github.event_name == 'pull_request'
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         message: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,10 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request'
     steps:
-      - uses: markwilson/html2pdf@v1.0
+      - uses: ferdinandkeller/html-to-pdf-action@v2
         with:
-          htmlPath: build/index.html
-          pdfName: build/register
+          - source-path: build/index.html
+          - destination-path: build/register.pdf
 
       - name: Upload the PDF as an artifact
         id: pdf-artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,6 @@ jobs:
           path: build/register.pdf
       
       - name: Add artifact links to the pull request
-        if: steps.finder
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,8 @@ jobs:
     steps:
       - uses: ferdinandkeller/html-to-pdf-action@v2
         with:
-          - source-path: build/index.html
-          - destination-path: build/register.pdf
+          source-path: build/index.html
+          destination-path: build/register.pdf
 
       - name: Upload the PDF as an artifact
         id: pdf-artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: build and test
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:
@@ -9,15 +9,40 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+
     - uses: actions/setup-node@v4
       with:
         node-version: '20'
+
     - run: npm install
+
     - run: npm run build
     - id: deployment
       uses: actions/upload-pages-artifact@v3
       with:
         path: build/
+
+  artifact:
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: markwilson/html2pdf@v1.0
+        with:
+          htmlPath: build/index.html
+          pdfName: build/register.pdf
+
+      - name: Upload the PDF as an artifact
+        id: pdf-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: register
+          path: build/register.pdf
+      
+      - name: Add artifact links to the pull request
+        if: steps.finder
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            Rendered register: <${{ steps.pdf-artifact.outputs.artifact-url}}>
 
   deploy:
     if: github.ref_name == github.event.repository.default_branch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,10 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request'
     steps:
-      - uses: ferdinandkeller/html-to-pdf-action@v2
+      - uses: fifsky/html-to-pdf-action@master
         with:
-          source-path: build/index.html
-          destination-path: build/register.pdf
+          htmlFile: ./build/index.html
+          outputFile: ./build/register.pdf
 
       - name: Upload the PDF as an artifact
         id: pdf-artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,10 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request'
     steps:
+      - uses: actions/download-artifact@v4
       - uses: fifsky/html-to-pdf-action@master
         with:
-          htmlFile: ./build/index.html
+          htmlFile: build/index.html
           outputFile: register.pdf
 
       - name: Upload the PDF as an artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
         path: build/
 
   artifact:
+    runs-on: ubuntu-latest
+    needs: build
     if: github.event_name == 'pull_request'
     steps:
       - uses: markwilson/html2pdf@v1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,14 +30,14 @@ jobs:
       - uses: fifsky/html-to-pdf-action@master
         with:
           htmlFile: ./build/index.html
-          outputFile: ./build/register.pdf
+          outputFile: register.pdf
 
       - name: Upload the PDF as an artifact
         id: pdf-artifact
         uses: actions/upload-artifact@v4
         with:
           name: register
-          path: build/register.pdf
+          path: register.pdf
       
       - name: Add artifact links to the pull request
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,29 +26,25 @@ jobs:
       with:
         path: build/
 
-  artifact:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/download-artifact@v4
-      - uses: fifsky/html-to-pdf-action@master
-        with:
-          htmlFile: build/index.html
-          outputFile: register.pdf
+    - uses: fifsky/html-to-pdf-action@master
+      if: github.event_name == 'pull_request'
+      with:
+        htmlFile: build/index.html
+        outputFile: build/register.pdf
 
-      - name: Upload the PDF as an artifact
-        id: pdf-artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: register
-          path: register.pdf
-      
-      - name: Add artifact links to the pull request
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          message: |
-            Rendered register: <${{ steps.pdf-artifact.outputs.artifact-url}}>
+    - name: Upload the PDF as an artifact
+      if: github.event_name == 'pull_request'
+      id: pdf-artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: register
+        path: build/register.pdf
+  
+    - name: Add artifact links to the pull request
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        message: |
+          Rendered register: <${{ steps.pdf-artifact.outputs.artifact-url}}>
 
   deploy:
     if: github.ref_name == github.event.repository.default_branch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: markwilson/html2pdf@v1.0
         with:
           htmlPath: build/index.html
-          pdfName: build/register.pdf
+          pdfName: build/register
 
       - name: Upload the PDF as an artifact
         id: pdf-artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,10 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request'
     steps:
-      - uses: ferdinandkeller/html-to-pdf-action@v2
+      - uses: fifsky/html-to-pdf-action@master
         with:
-          source-path: build/index.html
-          destination-path: build/register.pdf
+          htmlFile: ./build/index.html
+          outputFile: ./build/register.pdf
 
       - name: Upload the PDF as an artifact
         id: pdf-artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,23 +1,51 @@
 name: build and test
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+
     - uses: actions/setup-node@v4
       with:
         node-version: '20'
+
     - run: npm install
+
     - run: npm run build
+
     - id: deployment
       uses: actions/upload-pages-artifact@v3
       with:
         path: build/
+
+    - uses: fifsky/html-to-pdf-action@master
+      if: github.event_name == 'pull_request'
+      with:
+        htmlFile: build/index.html
+        outputFile: build/register.pdf
+
+    - name: Upload the PDF as an artifact
+      if: github.event_name == 'pull_request'
+      id: pdf-artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: register
+        path: build/register.pdf
+  
+    - name: Add artifact links to the pull request
+      if: github.event_name == 'pull_request'
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        message: |
+          Rendered register: <${{ steps.pdf-artifact.outputs.artifact-url}}>
 
   deploy:
     if: github.ref_name == github.event.repository.default_branch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,14 +34,14 @@ jobs:
       - uses: fifsky/html-to-pdf-action@master
         with:
           htmlFile: ./build/index.html
-          outputFile: ./build/register.pdf
+          outputFile: register.pdf
 
       - name: Upload the PDF as an artifact
         id: pdf-artifact
         uses: actions/upload-artifact@v4
         with:
           name: register
-          path: build/register.pdf
+          path: register.pdf
       
       - name: Add artifact links to the pull request
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,34 +17,31 @@ jobs:
     - run: npm install
 
     - run: npm run build
+
     - id: deployment
       uses: actions/upload-pages-artifact@v3
       with:
         path: build/
 
-  artifact:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/download-artifact@v4
-      - uses: fifsky/html-to-pdf-action@master
-        with:
-          htmlFile: build/index.html
-          outputFile: register.pdf
+    - uses: fifsky/html-to-pdf-action@master
+      if: github.event_name == 'pull_request'
+      with:
+        htmlFile: build/index.html
+        outputFile: build/register.pdf
 
-      - name: Upload the PDF as an artifact
-        id: pdf-artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: register
-          path: register.pdf
-      
-      - name: Add artifact links to the pull request
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          message: |
-            Rendered register: <${{ steps.pdf-artifact.outputs.artifact-url}}>
+    - name: Upload the PDF as an artifact
+      if: github.event_name == 'pull_request'
+      id: pdf-artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: register
+        path: build/register.pdf
+  
+    - name: Add artifact links to the pull request
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        message: |
+          Rendered register: <${{ steps.pdf-artifact.outputs.artifact-url}}>
 
   deploy:
     if: github.ref_name == github.event.repository.default_branch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,10 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request'
     steps:
+      - uses: actions/download-artifact@v4
       - uses: fifsky/html-to-pdf-action@master
         with:
-          htmlFile: ./build/index.html
+          htmlFile: build/index.html
           outputFile: register.pdf
 
       - name: Upload the PDF as an artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,6 @@ jobs:
           path: build/register.pdf
       
       - name: Add artifact links to the pull request
-        if: steps.finder
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: markwilson/html2pdf@v1.0
         with:
           htmlPath: build/index.html
-          pdfName: build/register.pdf
+          pdfName: build/register
 
       - name: Upload the PDF as an artifact
         id: pdf-artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,27 +26,6 @@ jobs:
       with:
         path: build/
 
-    - uses: fifsky/html-to-pdf-action@master
-      if: github.event_name == 'pull_request'
-      with:
-        htmlFile: build/index.html
-        outputFile: build/register.pdf
-
-    - name: Upload the PDF as an artifact
-      if: github.event_name == 'pull_request'
-      id: pdf-artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: register
-        path: build/register.pdf
-  
-    - name: Add artifact links to the pull request
-      if: github.event_name == 'pull_request'
-      uses: marocchino/sticky-pull-request-comment@v2
-      with:
-        message: |
-          Rendered register: <${{ steps.pdf-artifact.outputs.artifact-url}}>
-
   deploy:
     if: github.ref_name == github.event.repository.default_branch
     environment:

--- a/src/main/data/cpl-marker-labels.json
+++ b/src/main/data/cpl-marker-labels.json
@@ -583,27 +583,27 @@
     "authority": "IMF UG"
   },
   {
-    "label": "FFTease",
+    "label": "FFPromo",
     "scope": "https://www.imfug.com/ns/cpl-markers/2025",
     "seeAlso": [
       {
         "scope": "https://www.imfug.com/ns/cpl-markers/2025",
-        "label": "LFTease"
+        "label": "LFPromo"
       }
     ],
-    "description": "First Frame of Tease – A tease or other advertisement for an episode, season, series/show, or other work. This applies to recaps leadin or trailing teases rather than standalone recaps.",
+    "description": "First Frame of Promotion – promotional material associated with media. This includes teasers, trailers, electronic press kits and other materials.",
     "authority": "IMF UG"
   },
   {
-    "label": "LFTease",
+    "label": "LFPromo",
     "scope": "https://www.imfug.com/ns/cpl-markers/2025",
     "seeAlso": [
       {
         "scope": "https://www.imfug.com/ns/cpl-markers/2025",
-        "label": "FFTease"
+        "label": "FFPromo"
       }
     ],
-    "description": "Last Frame of Tease – A tease or other advertisement for an episode, season, series/show, or other work. This applies to recaps leadin or trailing teases rather than standalone recaps.",
+    "description": "Last Frame of Promotion – promotional material associated with media. This includes teasers, trailers, electronic press kits and other materials.",
     "authority": "IMF UG"
   },
   {
@@ -615,7 +615,7 @@
         "label": "LFAd"
       }
     ],
-    "description": "First Frame of Ad – An advertisement other than Tease",
+    "description": "First Frame of Ad – any form of advertisement including TV commercials, informercials, and public service announcements.",
     "authority": "IMF UG"
   },
   {
@@ -627,7 +627,7 @@
         "label": "FFAd"
       }
     ],
-    "description": "Last Frame of Ad – An advertisement other than Tease",
+    "description": "Last Frame of Ad – any form of advertisement including TV commercials, informercials, and public service announcements.",
     "authority": "IMF UG"
   },
   {
@@ -775,51 +775,27 @@
     "authority": "IMF UG"
   },
   {
-    "label": "FFLS",
+    "label": "FFPictureLocal",
     "scope": "https://www.imfug.com/ns/cpl-markers/2025",
     "seeAlso": [
       {
         "scope": "https://www.imfug.com/ns/cpl-markers/2025",
-        "label": "LFLS"
+        "label": "LFPictureLocal"
       }
     ],
-    "description": "First Frame of First/Last frame of Localization Sequence/Segement/Shot that contains any video that is localized",
+    "description": "First frame of Localization Sequence/Segement/Shot that contain any images that are localized",
     "authority": "IMF UG"
   },
   {
-    "label": "LFLS",
+    "label": "LFPictureLocal",
     "scope": "https://www.imfug.com/ns/cpl-markers/2025",
     "seeAlso": [
       {
         "scope": "https://www.imfug.com/ns/cpl-markers/2025",
-        "label": "FFLS"
+        "label": "FFPictureLocal"
       }
     ],
-    "description": "First Frame of First/Last frame of Localization Sequence/Segement/Shot that contains any video that is localized",
-    "authority": "IMF UG"
-  },
-  {
-    "label": "FFOT",
-    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
-    "seeAlso": [
-      {
-        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
-        "label": "LFOT"
-      }
-    ],
-    "description": "First Frame of First/Last frame of Tag that contains any sequence of credit content (mark-in/mark-out for credit sequence(tag))",
-    "authority": "IMF UG"
-  },
-  {
-    "label": "LFOT",
-    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
-    "seeAlso": [
-      {
-        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
-        "label": "FFOT"
-      }
-    ],
-    "description": "First Frame of First/Last frame of Tag that contains any sequence of credit content (mark-in/mark-out for credit sequence(tag))",
+    "description": "Last frame of Localization Sequence/Segement/Shot that contain any images that are localized",
     "authority": "IMF UG"
   },
   {

--- a/src/main/data/cpl-marker-labels.json
+++ b/src/main/data/cpl-marker-labels.json
@@ -125,7 +125,7 @@
     "seeAlso": [
       {
         "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
-        "label": "LFS"
+        "label": "LFSP"
       }
     ],
     "description": "First Frame of Digital Sync Pop",
@@ -161,7 +161,7 @@
     "seeAlso": [
       {
         "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
-        "label": " LTXC"
+        "label": "LTXC"
       }
     ],
     "description": "First Frame of Textless Title Credits",
@@ -185,7 +185,7 @@
     "seeAlso": [
       {
         "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
-        "label": "LFXM"
+        "label": "LTXM"
       }
     ],
     "description": "First Frame of Textless Material Segment",
@@ -209,7 +209,7 @@
     "seeAlso": [
       {
         "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
-        "label": "FFTB"
+        "label": "FFCB"
       }
     ],
     "description": "Last Frame of Commercial Blacks",
@@ -364,7 +364,7 @@
     "label": "LTXE",
     "seeAlso": [
       {
-        "scope": "http://www.smpte-ra.org/schemas/2067-3/20201320#standard-markers",
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
         "label": "FTXE"
       }
     ],
@@ -432,7 +432,7 @@
     "seeAlso": [
       {
         "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
-        "label": ""
+        "label": "FFOA"
       }
     ],
     "description": "Audio Last Frame. Last frame of audio ring-in/ring-out where the video is in black.",

--- a/src/main/data/cpl-marker-labels.json
+++ b/src/main/data/cpl-marker-labels.json
@@ -2,271 +2,848 @@
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFBT",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFBT"
+      }
+    ],
     "description": "First Frame of Bars and Tone",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFCB",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFCB"
+      }
+    ],
     "description": "First Frame of Commercial Blacks",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFCL",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFCL"
+      }
+    ],
     "description": "First Frame of Company/Production Logo",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFDL",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFDL"
+      }
+    ],
     "description": "First Frame of Distribution Logo",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFEC",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFEC"
+      }
+    ],
     "description": "First Frame of End Credits. First displayable frame of content that contains any intensity of the End Credits (a non zero alpha value), which appear at the end of a feature.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFHS",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFHS"
+      }
+    ],
     "description": "First Frame of Head Slate",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFMC",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFMC"
+      }
+    ],
     "description": "First displayable frame of content that contains any intensity of moving, rolling or scrolling credits (a non-zero alpha value), which appear at the end of the feature.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFOB",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFOB"
+      }
+    ],
     "description": "First Frame of Ratings Band. First displayable frame of content of the Rating Band, which is usually a slate at the beginning of a feature.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFOC",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFOC"
+      }
+    ],
     "description": "First Frame of Composition. The first frame of a composition that is intended for display.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFOI",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFOI"
+      }
+    ],
     "description": "First Frame of Intermission.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFSP",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFS"
+      }
+    ],
     "description": "First Frame of Digital Sync Pop",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFTC",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFTC"
+      }
+    ],
     "description": "First Frame of Title Credits. First displayable frame of content that contains any intensity of the Title Credits (a non zero alpha value), which appear at the beginning of a feature.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFTS",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFTS"
+      }
+    ],
     "description": "First Frame of Tail Slate",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FTXC",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": " LTXC"
+      }
+    ],
     "description": "First Frame of Textless Title Credits",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FTXE",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LTXE"
+      }
+    ],
     "description": "First Frame of Textless End Credits",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FTXM",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFXM"
+      }
+    ],
     "description": "First Frame of Textless Material Segment",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFBT",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFBT"
+      }
+    ],
     "description": "Last Frame of Bars and Tone",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFCB",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFTB"
+      }
+    ],
     "description": "Last Frame of Commercial Blacks",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFCL",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFCL"
+      }
+    ],
     "description": "Last Frame of Company/Production Logo",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFDL",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFDL"
+      }
+    ],
     "description": "Last Frame of Distribution Logo",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFEC",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFEC"
+      }
+    ],
     "description": "Last Frame of End Credits. Last displayable frame of content that contains any intensity of the End Credits (a non zero alpha value), which appear at the end of a feature.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFHS",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFHS"
+      }
+    ],
     "description": "Last Frame of Head Slate",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFMC",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFMC"
+      }
+    ],
     "description": "Last displayable frame of content that contains any intensity of moving, rolling or scrolling credits (a non-zero alpha value), which appear at the end of the feature.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFOB",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFOB"
+      }
+    ],
     "description": "Last Frame of Ratings Band. Last displayable frame of content of the Rating Band, which is usually a slate at the beginning of a feature.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFOC",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFOC"
+      }
+    ],
     "description": "Last Frame of Composition. The last frame of a composition that is intended for display.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFOI",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFOI"
+      }
+    ],
     "description": "Last Frame of Intermission.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFSP",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFSP"
+      }
+    ],
     "description": "Last Frame of Digital Sync Pop",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFTC",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFTC"
+      }
+    ],
     "description": "Last Frame of Title Credits. Last displayable frame of content that contains any intensity of the Title Credits (a non zero alpha value), which appear at the beginning of a feature.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFTS",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFTS"
+      }
+    ],
     "description": "Last Frame of Tail Slate",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LTXC",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FTXC"
+      }
+    ],
     "description": "Last frame of Textless Title Credits",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LTXE",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/20201320#standard-markers",
+        "label": "FTXE"
+      }
+    ],
     "description": "Last Frame of Textless End Credits",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LTXM",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FTXM"
+      }
+    ],
     "description": "Last frame of Textless Material Segment",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FPCI",
+    "seeAlso": [],
     "description": "Fixed Point Candidate Insertion. Indicates possible point in the timeline where it would be allowable to insert content downstrean. This is for material that may not have commercial blacks, but could indicate a candidate point where a commercial could be inserted.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFCO",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFCO"
+      }
+    ],
     "description": "First Frame of Candidate Overlay. First frame of a sequence of frames where overlays, e.g. commercial overlays, may be placed.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFCO",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "FFCO"
+      }
+    ],
     "description": "Last Frame of Candidate Overlay. Last frame of a sequence of frames where overlays, e.g. commercial overlays, may be placed.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "FFOA",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": "LFOA"
+      }
+    ],
     "description": "Audio First Frame. First frame of audio ring-in/ring-out where the video is in black.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
     "label": "LFOA",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2013#standard-markers",
+        "label": ""
+      }
+    ],
     "description": "Audio Last Frame. Last frame of audio ring-in/ring-out where the video is in black.",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2016#standard-markers",
     "label": "FFDC",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2016#standard-markers",
+        "label": "LFDC"
+      }
+    ],
     "description": "First Frame of Dubbing Credits. First displayable frame of content that contains any intensity of dubbing credits",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2016#standard-markers",
     "label": "LFDC",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2016#standard-markers",
+        "label": "FFDC"
+      }
+    ],
     "description": "Last Frame of Dubbing credits: Last displayable frame of content that contains any intensity of dubbing credits",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
     "label": "FFEI",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
+        "label": "LFEI"
+      }
+    ],
     "description": "First Frame of Episode Intro",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
     "label": "FFER",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
+        "label": "LFER"
+      }
+    ],
     "description": "First Frame of Episode Recap",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
     "label": "FFUN",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
+        "label": "LFUN"
+      }
+    ],
     "description": "First Frame of Up Next",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
     "label": "LFEI",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
+        "label": "FFEI"
+      }
+    ],
     "description": "Last Frame of Episode Intro",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
     "label": "LFER",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
+        "label": "FFER"
+      }
+    ],
     "description": "Last Frame of Episode Recap",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
   },
   {
     "scope": "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
     "label": "LFUN",
+    "seeAlso": [
+      {
+        "scope": "http://www.smpte-ra.org/schemas/2067-3/2020#standard-markers",
+        "label": "FFUN"
+      }
+    ],
     "description": "Last Frame of Up Next",
-    "definingDocument": "SMPTE ST 2067-3"
+    "authority": "SMPTE ST 2067-3"
+  },
+  {
+    "label": "FFCreditScene",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFCreditScene"
+      }
+    ],
+    "description": "First Frame of Credit Scene – A scene embedded in the credits, typically closing credits. This can be mid-credit or post-credit.",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFCreditScene",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFCreditScene"
+      }
+    ],
+    "description": "Last frame of Credit Scene – A scene embedded in the credits, typically closing credits. This can be mid-credit or post-credit.",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "FFRecap",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFRecap"
+      }
+    ],
+    "description": "First Frame of Recap – A recap of an episode, season, series/show, or other work. This applies to recaps leadin or trailing recaps rather than standalone recaps.",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFRecap",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFRecap"
+      }
+    ],
+    "description": "Last Frame of Recap – A recap of an episode, season, series/show, or other work. This applies to recaps leadin or trailing recaps rather than standalone recaps.",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "FFTease",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFTease"
+      }
+    ],
+    "description": "First Frame of Tease – A tease or other advertisement for an episode, season, series/show, or other work. This applies to recaps leadin or trailing teases rather than standalone recaps.",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFTease",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFTease"
+      }
+    ],
+    "description": "Last Frame of Tease – A tease or other advertisement for an episode, season, series/show, or other work. This applies to recaps leadin or trailing teases rather than standalone recaps.",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "FFAd",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFAd"
+      }
+    ],
+    "description": "First Frame of Ad – An advertisement other than Tease",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFAd",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFAd"
+      }
+    ],
+    "description": "Last Frame of Ad – An advertisement other than Tease",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "FFLogo",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFLogo"
+      }
+    ],
+    "description": "First Frame of Logo – Logos other than Company/Production or Distribution. For example, Network, Distributor, or Platform",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFLogo",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFLogo"
+      }
+    ],
+    "description": "Last Frame of Logo – Logos other than Company/Production or Distribution. For example, Network, Distributor, or Platform",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "FFAltEnding",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFAltEnding"
+      }
+    ],
+    "description": "First Frame of Alternate ending – An alternate ending",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFAltEnding",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFAltEnding"
+      }
+    ],
+    "description": "Last Frame of Alternate ending – An alternate ending",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "FFAddlCredits",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFAddlCredits"
+      }
+    ],
+    "description": "First Frame of Extra credits – Additional credits.",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFAddlCredits",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFAddlCredits"
+      }
+    ],
+    "description": "Last Frame of Extra credits – Additional credits.",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "FFAddlGraphics",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFAddlGraphics"
+      }
+    ],
+    "description": "First Frame of Additional graphics – Additional graphics",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFAddlGraphics",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFAddlGraphics"
+      }
+    ],
+    "description": "Last Frame of Additional graphics – Additional graphics",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "FFCompliance",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFCompliance"
+      }
+    ],
+    "description": "First Frame of Compliance event – Period of time that contains content not meeting some compliance standards (e.g., nudity, smoking, or language)",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFCompliance",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFCompliance"
+      }
+    ],
+    "description": "Last Frame of Compliance event – Period of time that contains content not meeting some compliance standards (e.g., nudity, smoking, or language)",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "FFTitleCard",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFTitleCard"
+      }
+    ],
+    "description": "First Frame of Title Card –The shows title graphic found within the 1st segment of a program. Could overlap with Opening sequence.",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFTitleCard",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFTitleCard"
+      }
+    ],
+    "description": "Last Frame of Title Card –The shows title graphic found within the 1st segment of a program. Could overlap with Opening sequence.",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "FFLS",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFLS"
+      }
+    ],
+    "description": "First Frame of First/Last frame of Localization Sequence/Segement/Shot that contains any video that is localized",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFLS",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFLS"
+      }
+    ],
+    "description": "First Frame of First/Last frame of Localization Sequence/Segement/Shot that contains any video that is localized",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "FFOT",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFOT"
+      }
+    ],
+    "description": "First Frame of First/Last frame of Tag that contains any sequence of credit content (mark-in/mark-out for credit sequence(tag))",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFOT",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFOT"
+      }
+    ],
+    "description": "First Frame of First/Last frame of Tag that contains any sequence of credit content (mark-in/mark-out for credit sequence(tag))",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "FFCallToAction",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "LFCallToAction"
+      }
+    ],
+    "description": "First Frame of Ad contains call to action like a web link \"visit www.savethewhales.org\"",
+    "authority": "IMF UG"
+  },
+  {
+    "label": "LFCallToAction",
+    "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+    "seeAlso": [
+      {
+        "scope": "https://www.imfug.com/ns/cpl-markers/2025",
+        "label": "FFCallToAction"
+      }
+    ],
+    "description": "First Frame of Ad contains call to action like a web link \"visit www.savethewhales.org\"",
+    "authority": "IMF UG"
   }
 ]

--- a/src/main/resources/static/main.css
+++ b/src/main/resources/static/main.css
@@ -2,6 +2,7 @@ body {
   overflow-x: hidden;
   font-family: Arial, Helvetica, sans-serif;
   margin: auto;
+  line-height: 125%;
 }
 
 /* toolbar */
@@ -72,7 +73,11 @@ footer {
 }
 
 #register th:nth-child(3) {
-  width: 30%;
+  width: 10%;
+}
+
+#register th:nth-child(4) {
+  width: 20%;
 }
 
 #register tbody tr:nth-child(even) {

--- a/src/main/scripts/build.mjs
+++ b/src/main/scripts/build.mjs
@@ -47,23 +47,30 @@ if (!register) {
 const scopes = new Map();
 for (const entry of register) {
   if (entry.scope === undefined) {
-    throw "Missing scope in entry";
+    throw "Missing scope property";
   }
   if (entry.label === undefined) {
-    throw "Missing label in entry";
+    throw "Missing label property";
   }
   if (entry.description === undefined) {
-    throw "Missing description in entry";
+    throw "Missing description property";
   }
-  if (entry.definingDocument === undefined) {
-    throw "Missing definingDocument in entry";
+  if (entry.authority === undefined) {
+    throw "Missing authority property";
+  }
+  if (entry.seeAlso === undefined) {
+    throw "Missing seeAlso property";
   }
   let labels = scopes.get(entry.scope);
   if (labels === undefined) {
     labels = [];
     scopes.set(entry.scope, labels);
   }
+  if (labels.some((e) => e.label === entry.label)) {
+    throw `Duplicate label: ${entry.scope} ${entry.label}`;
+  }
   labels.push(entry);
+
 }
 
 

--- a/src/main/templates/cpl-marker-labels.hbs
+++ b/src/main/templates/cpl-marker-labels.hbs
@@ -36,18 +36,24 @@
         <tr>
           <th>Label</th>
           <th>Description</th>
+          <th>See also</th>
           <th>Where is it defined?</th>
         </tr>
       </thead>
       {{#each scopes}}
         <tbody>
           <tr>
-            <th colspan="3"><code>scope</code>: <code>{{scope}}</code></th>
+            <th colspan="4"><code>scope</code>: <code>{{scope}}</code></th>
           </tr>
           {{#each labels}}
             <tr id="{{../scope}}-{{label}}">
               <td><code>{{label}}</code></td>
               <td>{{description}}</td>
+              <td>
+                {{#each seeAlso}}
+                 <a href="#{{scope}}-{{label}}">{{label}}</a> 
+                {{/each}}
+              </td>
               <td>{{authority}}</td>
             </tr>
           {{/each}}

--- a/src/main/templates/cpl-marker-labels.hbs
+++ b/src/main/templates/cpl-marker-labels.hbs
@@ -36,7 +36,7 @@
         <tr>
           <th>Label</th>
           <th>Description</th>
-          <th>Defining document</th>
+          <th>Where is it defined?</th>
         </tr>
       </thead>
       {{#each scopes}}
@@ -45,10 +45,10 @@
             <th colspan="3"><code>scope</code>: <code>{{scope}}</code></th>
           </tr>
           {{#each labels}}
-            <tr>
+            <tr id="{{../scope}}-{{label}}">
               <td><code>{{label}}</code></td>
               <td>{{description}}</td>
-              <td>{{definingDocument}}</td>
+              <td>{{authority}}</td>
             </tr>
           {{/each}}
         </tbody>


### PR DESCRIPTION
Add CPL Marker Labels per the [Ad Hoc report](https://github.com/user-attachments/files/19654725/new_marker_labels_v4.xlsx).

Outstanding questions:
* do `FFCreditScene` and `LFCreditScene` overlap with `FFOT` and `LFOT`
* should `FFLocalization` be used instead of `FFLS`?
* `FFOT`/`LFOT`: what is a _tag_? Potentially overlaps with `FFCreditScene`. Should `FFOfTag` be used instead?
